### PR TITLE
fixed new users unable to see pics

### DIFF
--- a/lib/ft_42.rb
+++ b/lib/ft_42.rb
@@ -61,7 +61,7 @@ class FT_42
         user_sessions_print.sessions
       elsif args.second == "pic"
         if ENV["TERM_PROGRAM"] == "iTerm.app"
-          system "iterm2-viewer /nfs/intrav2cdn/users/medium_#{args.first}.jpeg"
+          system "iterm2-viewer /nfs/intrav2cdn/users/medium_#{args.first}.jpg"
         end
         user_print.all
         user_sessions_print.all


### PR DESCRIPTION
new cadet images saved as .jpg and not as .jpeg, tested on older cadets as well, the old images have .jpg aliases